### PR TITLE
Feature/defaultvalues

### DIFF
--- a/pkg/handlers/helm.go
+++ b/pkg/handlers/helm.go
@@ -557,9 +557,10 @@ func (appContext *AppContext) helmDryRun(w http.ResponseWriter, r *http.Request)
 
 }
 
-func (appContext *AppContext) getArgs(variables []model.Variable, globalVariables []model.Variable, environment *model.Environment) []string {
+func (appContext *AppContext) getArgsWithHelmDefault(variables []model.Variable, helmVars map[string]interface{}, globalVariables []model.Variable, environment *model.Environment) []string {
 
 	var args []string
+	var keys []string
 	for i, item := range variables {
 		if item.Secret {
 			byteValues, _ := hex.DecodeString(item.Value)
@@ -569,9 +570,27 @@ func (appContext *AppContext) getArgs(variables []model.Variable, globalVariable
 			}
 		}
 		if len(item.Name) > 0 && len(item.Value) > 0 {
-			args = append(args, normalizeVariableName(item.Name)+"="+replace(item.Value, *environment, globalVariables))
+			value := replace(item.Value, *environment, globalVariables)
+			args = append(args, normalizeVariableName(item.Name)+"="+value)
+			if value != "" {
+				keys = append(keys, normalizeVariableName(item.Name))
+			}
 		}
 	}
+
+	dt := time.Now()
+	args = append(args, "app.dateHour="+dt.String())
+	keys = append(keys, "app.dateHour")
+
+	for key, value := range helmVars {
+		if !util.Contains(keys, normalizeVariableName(key)) {
+			svalue, ok := value.(string)
+			if ok {
+				args = append(args, normalizeVariableName(key)+"="+replace(svalue, *environment, globalVariables))
+			}
+		}
+	}
+
 	return args
 }
 
@@ -586,15 +605,16 @@ func (appContext *AppContext) simpleInstall(environment *model.Environment, inst
 	variables, err := appContext.Repositories.VariableDAO.GetAllVariablesByEnvironmentAndScope(int(environment.ID), searchTerm)
 	globalVariables := appContext.getGlobalVariables(int(environment.ID))
 
-	args := appContext.getArgs(variables, globalVariables, environment)
+	helmVars, err := appContext.getHelmChartAppVars(installPayload.Chart, installPayload.ChartVersion)
+	if err != nil {
+		return "", err
+	}
+	args := appContext.getArgsWithHelmDefault(variables, helmVars, globalVariables, environment)
 
 	//Add Default Gateway
 	if len(environment.Gateway) > 0 {
 		args = append(args, "istio.virtualservices.gateways[0]="+environment.Gateway)
 	}
-
-	dt := time.Now()
-	args = append(args, "app.dateHour="+dt.String())
 
 	if err == nil {
 		name := installPayload.Name + "-" + environment.Namespace

--- a/pkg/handlers/helm.go
+++ b/pkg/handlers/helm.go
@@ -571,10 +571,13 @@ func (appContext *AppContext) getArgsWithHelmDefault(variables []model.Variable,
 		}
 		if len(item.Name) > 0 && len(item.Value) > 0 {
 			value := replace(item.Value, *environment, globalVariables)
-			args = append(args, normalizeVariableName(item.Name)+"="+value)
 			if value != "" {
 				keys = append(keys, normalizeVariableName(item.Name))
 			}
+			if value == "T_EMPTY" {
+				value = ""
+			}
+			args = append(args, normalizeVariableName(item.Name)+"="+value)
 		}
 	}
 

--- a/pkg/handlers/helm_test.go
+++ b/pkg/handlers/helm_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/softplan/tenkai-api/pkg/dbms/model"
 	mockRepo "github.com/softplan/tenkai-api/pkg/dbms/repository/mocks"
 	helmapi "github.com/softplan/tenkai-api/pkg/service/_helm"
+	"github.com/softplan/tenkai-api/pkg/service/_helm/mocks"
 	mockSvc "github.com/softplan/tenkai-api/pkg/service/_helm/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -581,6 +582,11 @@ func TestGetHelmCommand(t *testing.T) {
 	mockVariableDAO := mockGetAllVariablesByEnvironmentAndScope(&appContext)
 	mockConvention := mockConventionInterface(&appContext)
 
+	chartValue := `{"app":{"myvar":"myvalue"}}`
+	mockHelmSvc := &mocks.HelmServiceInterface{}
+	mockHelmSvc.On("GetTemplate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]byte(chartValue), nil)
+	appContext.HelmServiceAPI = mockHelmSvc
+
 	mockPrincipal(req)
 
 	rr := httptest.NewRecorder()
@@ -649,9 +655,8 @@ func TestMultipleInstall(t *testing.T) {
 	mockHelmSvc := mockUpgrade(&appContext)
 	mockHelmSvc.On("SearchCharts", mock.Anything, false).Return(charts)
 
-	result := []byte("it doesn't have a config map")
-	mockHelmSvc.On("GetTemplate", mock.Anything, mock.Anything, mock.Anything,
-		mock.Anything).Return(result, nil)
+	chartValue := `{"app":{"myvar":"myvalue"}}`
+	mockHelmSvc.On("GetTemplate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]byte(chartValue), nil)
 
 	user := mockUser()
 	mockUserDAO := &mockRepo.UserDAOInterface{}
@@ -738,6 +743,9 @@ func TestInstall(t *testing.T) {
 	mockUserEnvRoleDAO.On("GetRoleByUserAndEnvironment", user, mock.Anything).
 		Return(&secOper, nil)
 
+	chartValue := `{"app":{"myvar":"myvalue"}}`
+	mockHelmSvc.On("GetTemplate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]byte(chartValue), nil)
+
 	appContext.Repositories.UserDAO = mockUserDAO
 	appContext.Repositories.UserEnvironmentRoleDAO = mockUserEnvRoleDAO
 
@@ -764,6 +772,9 @@ func TestDryRun(t *testing.T) {
 	mockConvention := mockConventionInterface(&appContext)
 	mockHelmSvc := mockUpgrade(&appContext)
 	mockHelmSvc.On("SearchCharts", mock.Anything, false).Return(getCharts())
+
+	chartValue := `{"app":{"myvar":"myvalue"}}`
+	mockHelmSvc.On("GetTemplate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]byte(chartValue), nil)
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(appContext.helmDryRun)

--- a/pkg/handlers/promote_handler_test.go
+++ b/pkg/handlers/promote_handler_test.go
@@ -23,6 +23,9 @@ func doTest(t *testing.T, mode string) {
 	mockHelmSvc := mockHelmSvcWithLotOfThings(&appContext)
 	mockHelmSvc.On("SearchCharts", mock.Anything, false).Return(getCharts())
 
+	chartValue := `{"app":{"myvar":"myvalue"}}`
+	mockHelmSvc.On("GetTemplate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]byte(chartValue), nil)
+
 	auditSvc := &mockAudit.AuditingInterface{}
 	auditSvc.On("DoAudit", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 


### PR DESCRIPTION
This commit is adding the helm chart default values from values.yaml as a really default value. 
The interpolation capability using ${} syntax is now possible  and it will be evaluate in each deployment.
T_EMPTY constant was added to enable a way to force a field to be empty, because now, if the field is empty, the default value is always used.
